### PR TITLE
Update years in copyright example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you would like to see the detailed LICENSE click [here](LICENSE).
 
 ```text
 #
-# Copyright IBM Corp. 2020-
+# Copyright IBM Corp. {Year project was created} - {Current Year}
 # SPDX-License-Identifier: Apache2.0
 #
 ```


### PR DESCRIPTION
Update the copyright example in README.md to show place holders for the years rather than a literal "2020". As suggested by @byoboo.