### PR TITLE
Fix SPDX identifier in copyright example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you would like to see the detailed LICENSE click [here](LICENSE).
 ```text
 #
 # Copyright IBM Corp. 2020-
-# SPDX-License-Identifier: Apache2.0
+# SPDX-License-Identifier: Apache-2.0
 #
 ```
 ## Authors


### PR DESCRIPTION
As reported in #10 by @jpe15, the SPDX identifier was wrong in the copyright example. The correct string is "Apache-2.0".